### PR TITLE
Add support for handlebars options argument

### DIFF
--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -123,7 +123,20 @@ export const resolveExpression = (
 export const resolveHelper = (
   expression: Glimmer.MustacheStatement | Glimmer.SubExpression
 ): Babel.CallExpression => {
-  return Babel.callExpression(Babel.identifier(expression.path.original?.toString() ?? 'undefined'), expression.params.map(resolveExpression))
+  const params: Array<Babel.Expression> = expression.params.map(resolveExpression);
+
+  // Handlebars helpers always take an options argument as the last parameter
+  params.push(
+    Babel.objectExpression(
+      expression.hash.pairs.map((pair) => {
+        return Babel.objectProperty(
+          Babel.stringLiteral(pair.key), 
+          resolveExpression(pair.value)
+        )
+      })
+    )
+  )
+  return Babel.callExpression(Babel.identifier(expression.path.original?.toString() ?? 'undefined'), params)
 }
 
 /**


### PR DESCRIPTION
Handlebars helper calls always take an options argument, which can be keyed like:

```hbs
<span class="type-name">{{__ this key="activity-item:type" context=this.activityItemEditMetaTypeContext}}</span>
```

See: https://handlebarsjs.com/guide/expressions.html#helpers-with-hash-arguments

In this PR the result would be:

```tsx
<span className="type-name">{__(props, {
        "key": "activity-item:type",
        "context": props.activityItemEditMetaTypeContext
})}</span>
```

You can see in our `joinArgs` helper that it always expects the options object to be present:

```js
module.exports = function (...args) {
    return args
        .slice(0, -1) // Handlebars passes an extra object in arguments
        .join("");
};
```